### PR TITLE
Update Get-CRTReport.ps1

### DIFF
--- a/Get-CRTReport.ps1
+++ b/Get-CRTReport.ps1
@@ -791,7 +791,7 @@ if ($continue) {
     };
     $SMTPForward = $null;
     try {
-        [array]$SMTPForward = Get-EXOMailbox -ResultSize Unlimited | Where-Object {($_.ForwardingAddress -ne $null -or $_.ForwardingSMTPAddress -ne $null)} | Select-Object Name,ForwardingAddress,ForwardingSMTPAddress,DeliverToMailboxAndForward;
+        [array]$SMTPForward = Get-EXOMailbox -PropertySets Delivery -ResultSize Unlimited | Where-Object {($_.ForwardingAddress -ne $null -or $_.ForwardingSMTPAddress -ne $null)} | Select-Object Name,ForwardingAddress,ForwardingSMTPAddress,DeliverToMailboxAndForward;
         if($SMTPForward.Count -gt 0) {
             try {
                 $SMTPForward | Export-Csv "$reportsFolder\MailForwardingRules.csv" -NoTypeInformation;


### PR DESCRIPTION
Added specification of 'PropertySets Delivery' to Get-EXOMailbox, in larger tenants not all attributes (in this case forwarding) are included. The base set does not include these.
https://docs.microsoft.com/en-us/powershell/exchange/cmdlet-property-sets?view=exchange-ps