### PR TITLE
Add TransportRule command and other changes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,7 @@ Exchange Online (O365):
 - Client Access Settings Configured on Mailboxes
 - Mail Forwarding Rules for Remote Domains
 - Mailbox SMTP Forwarding Rules
+- Mail Transport Rules
 - Delegates with 'Full Access' Permission Granted
 - Delegates with Any Permissions Granted
 - Delegates with 'Send As' or 'SendOnBehalf' Permissions
@@ -70,6 +71,7 @@ FedTrust
 ClientAccess
 RemoteDomains
 SMTPForward
+TransportRule
 FullAccessGranted
 AnyAccessGranted
 SendAsGranted


### PR DESCRIPTION
* Based @brianreidc7 patch.
  + https://github.com/brianreidc7/CRT/tree/patch-1
* Add "-ListAvailable" with Get-Module
  + This will prevent the module from being installed again, even if it has been installed.
* Add TransportRule command
  + Added a command to output the Transport Rule for Exchange Online. This will allow you to know when you are abusing the Transport Rule, such as forwarding all emails to an external email address with BCC.
* Add "-Encoding Default" with Export-Csv
  + Addedd "-Encoding Default" with all Export-Csv. This will ensure that multi-byte character strings are correctly output in CSV output according to the execution environment. Note that this option has been confirmed to work with PowerShell 5.1, but may not work with later versions.
* Add "-PropertySets Minimum,Delivery" and change some output with Get-EXOMailbox
  + This is based on a change made by @roel80, where the PropertySets in Get-EXOMailbox are set to Minimum and Delivery, so that the minimum necessary data can be extracted. If you don't specify Delivery, Minimum will be specified by default and ForwardingSMTPAddress will be output empty. Minimum is used to get the Name property.