### PR TITLE
Add DisplayName to serviceprinciple report.

### DIFF
--- a/Get-CRTReport.ps1
+++ b/Get-CRTReport.ps1
@@ -1633,6 +1633,7 @@ if ($continue) {
                 $ObjectProperties = [Ordered]@{
                     "ObjectId" = ($obj.ObjectId | Out-String).Trim()
                     "AppId" = ($obj.AppId | Out-String).Trim()
+		     "DisplayName" = ($obj.DisplayName | Out-String).Trim()
                     "StartDate" = ($KeyCred.StartDate | Out-String).Trim()
                     "EndDate" = ($KeyCred.EndDate | Out-String).Trim()
                     "KeyId" = ($KeyCred.KeyId | Out-String).Trim()

--- a/Get-CRTReport.ps1
+++ b/Get-CRTReport.ps1
@@ -1633,7 +1633,7 @@ if ($continue) {
                 $ObjectProperties = [Ordered]@{
                     "ObjectId" = ($obj.ObjectId | Out-String).Trim()
                     "AppId" = ($obj.AppId | Out-String).Trim()
-		     "DisplayName" = ($obj.DisplayName | Out-String).Trim()
+		            "DisplayName" = ($obj.DisplayName | Out-String).Trim()
                     "StartDate" = ($KeyCred.StartDate | Out-String).Trim()
                     "EndDate" = ($KeyCred.EndDate | Out-String).Trim()
                     "KeyId" = ($KeyCred.KeyId | Out-String).Trim()


### PR DESCRIPTION
I thought it would be helpful to have the display name added to the ServicePrincipalObjects exports